### PR TITLE
Add support to max network concurrent requests

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -80,6 +80,7 @@ commander.option(
   '--no-progress',
   'disable progress bar',
 );
+commander.option('--concurrency <number>', 'maximum number of concurrent network requests')
 
 // get command name
 let commandName: ?string = args.shift() || '';
@@ -360,6 +361,7 @@ config.init({
   production: commander.production,
   httpProxy: commander.proxy,
   httpsProxy: commander.httpsProxy,
+  concurrency: commander.concurrency,
   commandName,
 }).then(() => {
   const exit = () => {

--- a/src/config.js
+++ b/src/config.js
@@ -34,6 +34,7 @@ export type ConfigOptions = {
   cafile?: ?string,
   production?: boolean,
   binLinks?: boolean,
+  concurrency?: number,
 
   // Loosely compare semver for invalid cases like "0.01.0"
   looseSemver?: ?boolean,
@@ -202,6 +203,7 @@ export default class Config {
       cafile: String(opts.cafile || this.getOption('cafile') || ''),
       cert: String(opts.cert || this.getOption('cert') || ''),
       key: String(opts.key || this.getOption('key') || ''),
+      concurrency: Number(opts.concurrency || this.getOption('concurrency') || constants.NETWORK_CONCURRENCY),
     });
   }
 

--- a/src/util/request-manager.js
+++ b/src/util/request-manager.js
@@ -42,6 +42,7 @@ type RequestParams<T> = {
   encoding?: ?string,
   ca?: Array<string>,
   cert?: string,
+  concurrency?: number,
   key?: string,
   forever?: boolean,
   strictSSL?: boolean,
@@ -114,6 +115,7 @@ export default class RequestManager {
     ca?: Array<string>,
     cafile?: string,
     cert?: string,
+    concurrency?: number,
     key?: string,
   }) {
     if (opts.userAgent != null) {
@@ -142,6 +144,10 @@ export default class RequestManager {
 
     if (opts.ca != null && opts.ca.length > 0) {
       this.ca = opts.ca;
+    }
+
+    if (opts.concurrency != null) {
+      this.max = opts.concurrency;
     }
 
     if (opts.cafile != null && opts.cafile != '') {


### PR DESCRIPTION
**Summary**

In my organization we are consuming many private dependencies as GitHub private repositories through ssh (i.e. `git+ssh://git@github.com/org/name.git`), which results that when the number of these dependencies exceeds some limit (around 10), the number of concurrent requests to GitHub from the same IP will result in a `Connection reset by peer error` which is a DDoS protection from GitHub. 

Fixes https://github.com/yarnpkg/yarn/issues/1307

Since yarn will cache all successful fetches, it really does not matter that the first fetch of dependencies is a bit slow.

Let me know if `concurrency` is also the proper name, I'm thinking if I should use `network-concurrency` instead?

**Test plan**

Running `yarn install --concurrency 1` on https://github.com/albertfdp/yarn-github-repos should not raise a `Connection reset by peer` error.

I've been looking into the tests at https://github.com/yarnpkg/yarn/blob/master/__tests__/util/request-manager.js but I'm not sure how to add a test to verify the concurrency. I'd be very happy to add a unit test if I can get some guidance.
